### PR TITLE
Removed extra lines and commit() from DB delete

### DIFF
--- a/models/engine/db_storage.py
+++ b/models/engine/db_storage.py
@@ -72,8 +72,6 @@ class DBStorage:
         """delete from the current database session obj if not None"""
         if obj is not None:
             self.__session.delete(obj)
-            self.save()
-
 
     def reload(self):
         """reloads data from the database"""

--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -75,7 +75,6 @@ class FileStorage:
                 del self.__objects[key]
                 self.save()
 
-
     def close(self):
         """call reload() method for deserializing the JSON file to objects"""
         self.reload()


### PR DESCRIPTION
Removed `self.commit()` from `DBStorage.delete(self)` to silence errors. Also erased extra newlines.